### PR TITLE
Add info how to generate cover report for .NET Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ choco install opencover.portable
 
 the OpenCover commandline will become available.
 
-### xUnit
+Generation of coverage report is slighly different depending on the .NET platform of your test projects.
+
+### .NET Framework project
+
+#### xUnit
 
 First install the xUnit console runner via [Nuget](https://www.nuget.org/packages/xunit.runner.console/2.3.0-beta1-build3642) or [Chocolatey](https://chocolatey.org/packages/XUnit). If we run the following in PowerShell to install xUnit via Chocolatey
 
@@ -36,7 +40,7 @@ OpenCover.Console.exe -register:user -target:"xunit.console.x86.exe" -targetargs
 
 Then a coverage report will be generated.
 
-### MSTest
+#### MSTest
 
 Execute the following in your solution's root,
 
@@ -45,6 +49,29 @@ OpenCover.Console.exe -register:user -target:"C:\Program Files (x86)\Microsoft V
 ```
 
 where you may need to change the `-target` flag to point to the correct version of MSTest.
+
+
+### .NET Core project
+
+If you don't yet have .NET Core SDK installed, install it
+
+```powershell
+choco install dotnetcore-sdk
+```
+
+In case of .NET Core projects, there is no difference between `MSTest` and `xUnit` for coverage report generation.
+
+Make sure all covered projects generate full pdb file (not only test projects), either through `<DebugType>full</DebugType>` in the `.csproj` file or by using a Visual Studio: Project Properties > Build > Advanced > Debugging information. By default, projects created by `dotnet` or by Visual Studio use a portable format for pdb files. Support for portable pdb format [hasn't been released in OpenCover yet](https://github.com/OpenCover/opencover/issues/610). If you fail to set full pdb, the `OpenCover` will print out a message notifying you that it has no results along with common causes.
+
+The .NET Core test assembly can't be run by a `xunit.console.x86.exe`, because that tool works only with .NET Framework assemblies. The tests are run by `dotnet test` (possibly `dotnet xunit` if you [add dotnet-xunit](https://xunit.github.io/docs/getting-started-dotnet-core.html#create-project) CLI tool to your project).
+
+Execute the following command in your solution's root:
+
+```powershell
+OpenCover.Console.exe -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:test -filter:"+[UnitTestTargetProject*]* -[MyUnitTests*]*" -output:".\MyProject_coverage.xml" -oldstyle
+```
+
+where `-oldstyle` switch is necessary, because .NET Core uses `System.Private.CoreLib` instead of `mscorlib` and thus `OpenCover` can't use  `mscorlib` for code instrumentation. You may also need to change the location of `dotnet.exe` to depending on the installed location.
 
 ## Uploading Report
 


### PR DESCRIPTION
.NET Core has worse tool support than .NET Framework and requires few different steps.